### PR TITLE
Added fix for YAMLLoadWarning

### DIFF
--- a/yaml_parser.py
+++ b/yaml_parser.py
@@ -17,7 +17,7 @@ def parse_yaml(test_params, input_yaml_file):
     inv = test_params.master_invoke
     with open(input_yaml_file, 'r') as f:
         try:
-            y = yaml.load(f)
+            y = yaml.safe_load(f)
             if y == None:
                 y = {}
         except yaml.YAMLError as e:


### PR DESCRIPTION
root@6108652ee961 smallfile-master]# python smallfile_cli.py --yaml-input-file smallfile-yaml-inp.yaml 
/root/smallfile-master/yaml_parser.py:20: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.