### PR TITLE
Declare smallfile_cli.py as being Python3

### DIFF
--- a/smallfile_cli.py
+++ b/smallfile_cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # because it uses the "multiprocessing" python module instead of "threading"

--- a/smallfile_rsptimes_stats.py
+++ b/smallfile_rsptimes_stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # smallfile_rsptimes_stats.py -- python program to reduce response time sample data from smallfile benchmark to
 # statistics.  


### PR DESCRIPTION
Packaging `smallfile` on Fedora 31 gives an error without this change.