### PR TITLE
add 'truncate-overwrite' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,9 @@ beforehand)
 * ls-l -- scan directories and read basic file metadata
 * cleanup -- delete any pre-existing files from a previous run 
 * swift-put -- simulates OpenStack Swift behavior when doing PUT operation
-* swift-get -- simulates OpenStack Swift behavior for each GET operation. 
+* swift-get -- simulates OpenStack Swift behavior for each GET operation.
+* overwrite -- overwrite existing files.
+* truncate-overwrite -- truncate existing file and then write data to it.
 
 For example, if you want to run smallfile_cli.py on 1 host with 8 threads
 each creating 2 GB of 1-MiB files, you can use these options:

--- a/regtest.sh
+++ b/regtest.sh
@@ -391,7 +391,7 @@ supported_ops()
         if [ -n "$multitop" ] ; then single_topdir_ops='' ; fi
         
         # for debug only: ops="create cleanup"
-        ops="cleanup create append overwrite read $single_topdir_ops chmod stat $xattr_ops symlink mkdir rmdir rename delete-renamed"
+        ops="cleanup create append overwrite truncate-overwrite read $single_topdir_ops chmod stat $xattr_ops symlink mkdir rmdir rename delete-renamed"
         echo $ops
 }
 


### PR DESCRIPTION
some file systems have a different behavior for overwrite and truncate