### PR TITLE
automation: fix tests and run on windows too

### DIFF
--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install required dependencies
         run: pip install PyYAML
       - name: Run unit tests
-        run: python3 -m coverage run -m unittest yaml_parser.py
+        run: python3 -m coverage run -m unittest yaml_parser.py invoke_process.py smallfile.py
       - name: Collect coverage report
         run: |
           python3 -m coverage html
@@ -42,5 +42,32 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: coverage
+          path: htmlcov
+          if-no-files-found: error
+  windows:
+    name: Code Check on Windows
+    runs-on: windows-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Install coverage
+        run: pip install coverage html2text
+      - name: Install required dependencies
+        run: pip install PyYAML
+      - name: Run unit tests
+        run: python3 -m coverage run -m unittest yaml_parser.py invoke_process.py smallfile.py
+      - name: Collect coverage report
+        run: |
+          python3 -m coverage html
+      - name: Publish coverage report to job summary
+        run: html2text --ignore-images --ignore-links -b 0 htmlcov/index.html >> $env:GITHUB_STEP_SUMMARY
+      - name: Upload coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: win-coverage
           path: htmlcov
           if-no-files-found: error

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,4 +13,4 @@ repos:
       - id: isort
         name: isort (python3)
         language_version: python3
-        args: ["--check"]
+        args: ["--check", "--profile=black"]

--- a/drop_buffer_cache.py
+++ b/drop_buffer_cache.py
@@ -34,6 +34,9 @@ def load_libc_function(func_name):
     except AttributeError:
         # print("Unable to locate %s in libc.  Leaving as a no-op."% func_name)
         pass
+    except Exception:
+        # libc not available
+        pass
     return func
 
 

--- a/fallocate.py
+++ b/fallocate.py
@@ -35,6 +35,8 @@ def load_libc_function(func_name):
     except AttributeError:
         # print("Unable to locate %s in libc.  Leaving as a no-op."% func_name)
         pass
+    except Exception:
+        pass
     return func
 
 

--- a/invoke_process.py
+++ b/invoke_process.py
@@ -73,7 +73,7 @@ class Test(unittest_module.TestCase):
         self.invok.tid = "regtest"
         self.invok.start_log()
         shutil.rmtree(self.invok.src_dirs[0], ignore_errors=True)
-        os.makedirs(self.invok.src_dirs[0], 0o644)
+        os.makedirs(self.invok.src_dirs[0])
 
     def test_multiproc_stonewall(self):
         self.invok.log.info("starting stonewall test")

--- a/yaml_parser.py
+++ b/yaml_parser.py
@@ -6,6 +6,7 @@ modifies test_params object with contents of YAML file
 """
 
 import os
+import tempfile
 
 import yaml
 
@@ -134,21 +135,21 @@ class TestYamlParse(unittest_module.TestCase):
         self.params = None
 
     def test_parse_empty(self):
-        fn = "/tmp/sample_parse_empty.yaml"
+        fn = os.path.join(tempfile.gettempdir(), "sample_parse_empty.yaml")
         with open(fn, "w") as f:
             f.write("\n")
         parse_yaml(self.params, fn)
         # just looking for no exception here
 
     def test_parse_all(self):
-        fn = "/tmp/sample_parse.yaml"
+        fn = os.path.join(tempfile.gettempdir(), "sample_parse.yaml")
         with open(fn, "w") as f:
             f.write("operation: create\n")
         parse_yaml(self.params, fn)
         assert self.params.master_invoke.opname == "create"
 
     def test_parse_negint(self):
-        fn = "/tmp/sample_parse_negint.yaml"
+        fn = os.path.join(tempfile.gettempdir(), "sample_parse_negint.yaml")
         with open(fn, "w") as f:
             f.write("files: -3\n")
         try:
@@ -159,14 +160,16 @@ class TestYamlParse(unittest_module.TestCase):
                 raise e
 
     def test_parse_hostset(self):
-        fn = "/tmp/sample_parse_hostset.yaml"
+        fn = os.path.join(tempfile.gettempdir(), "sample_parse_hostset.yaml")
         with open(fn, "w") as f:
             f.write("host-set: host-foo,host-bar\n")
         parse_yaml(self.params, fn)
         assert self.params.host_set == ["host-foo", "host-bar"]
 
     def test_parse_fsdistr_exponential(self):
-        fn = "/tmp/sample_parse_fsdistr_exponential.yaml"
+        fn = os.path.join(
+            tempfile.gettempdir(), "sample_parse_fsdistr_exponential.yaml"
+        )
         with open(fn, "w") as f:
             f.write("file-size-distribution: exponential\n")
         parse_yaml(self.params, fn)
@@ -176,7 +179,7 @@ class TestYamlParse(unittest_module.TestCase):
         )
 
     def test_parse_dir_list(self):
-        fn = "/tmp/sample_parse_dirlist.yaml"
+        fn = os.path.join(tempfile.gettempdir(), "sample_parse_dirlist.yaml")
         with open(fn, "w") as f:
             f.write("top: foo,bar \n")
         parse_yaml(self.params, fn)


### PR DESCRIPTION
- use noop on exception while loading libc for Windows compatibility
- adapt unittests for windows filesystems
- run all unittests on linux and windows

# On Linux:
## Coverage report: 72%

Module | statements | missing | excluded | coverage  
---|---|---|---|---  
drop_buffer_cache.py | 35 | 17 | 0 | 51%  
fallocate.py | 37 | 19 | 0 | 49%  
invoke_process.py | 98 | 18 | 0 | 82%  
parser_data_types.py | 49 | 27 | 0 | 45%  
smallfile.py | 1450 | 328 | 0 | 77%  
smf_test_params.py | 98 | 69 | 0 | 30%  
sync_files.py | 47 | 21 | 0 | 55%  
yaml_parser.py | 146 | 57 | 0 | 61%  
Total | 1960 | 556 | 0 | 72%  

# On Windows
## Coverage report: 71%

Module | statements | missing | excluded | coverage  
---|---|---|---|---  
drop_buffer_cache.py | 35 | 15 | 0 | 57%  
fallocate.py | 37 | 17 | 0 | 54%  
invoke_process.py | 98 | 18 | 0 | 82%  
parser_data_types.py | 49 | 27 | 0 | 45%  
smallfile.py | 1450 | 339 | 0 | 77%  
smf_test_params.py | 98 | 69 | 0 | 30%  
sync_files.py | 47 | 21 | 0 | 55%  
yaml_parser.py | 146 | 57 | 0 | 61%  
Total | 1960 | 563 | 0 | 71%  

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>